### PR TITLE
Delete session map to avoid missing cas-session cookie creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Delete session map to avoid missing cas-session cookie creation 
 
 ## [v2.3.0] - 2025-10-08
 ### Changed

--- a/client.go
+++ b/client.go
@@ -75,6 +75,7 @@ func NewClient(options *Options) *Client {
 
 func (c *Client) Logout(w http.ResponseWriter, r *http.Request) {
 	c.clearSession(w, r)
+	c.sessions = map[string]string{}
 }
 
 // CreateHandler wraps an http.Handler to provide CAS authentication for the handler.


### PR DESCRIPTION
The symptoms are:
- missing cookie `_cas-session` on "/" URL path
- instead a cookie `TGC` on "/cas" URL path